### PR TITLE
Explain how to activate plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ plugins
          ･･･ 
 ```
 
+To activate elFinder go to Setting→CMS→Filebrowser→Name and enter `elfinder_xh`.
+
 ## Support
 * [CMSimple_XH Forum /Addons and Plugins](http://cmsimpleforum.com/viewtopic.php?f=12&t=10524)
 * [elFinder Issues](https://github.com/Studio-42/elFinder/issues)

--- a/admin.php
+++ b/admin.php
@@ -25,6 +25,10 @@ if (!defined('CMSIMPLE_XH_VERSION')) {
     exit;
 }
 
+if (function_exists('XH_registerPluginType')) {
+	XH_registerPluginType('filebrowser', $plugin);
+}
+
 // Read elFinder's Json file
 $json = file_get_contents($pth['folder']['plugins']. $plugin .'/elfinder/package.json');
 $array = json_decode( $json , true ) ;


### PR DESCRIPTION
Additionally, we register the filebrowser plugin (works for CMSimple_XH

> = 1.6.2) so the user can pick it from a datalist if supported by
> the browser.
