### PR TITLE
Make plugin administration available in CMSimple_XH 1.7

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -55,7 +55,7 @@ define('ELFINDER_XH_VERSION', '1.05_bild'.$array["version"] );
 
 
 if (!class_exists('Elfinder')) require dirname(__FILE__)."/elfinder.php";
-if(isset($elfinder_xh))
+if(function_exists('XH_wantsPluginAdministration') && XH_wantsPluginAdministration('elfinder_xh') || isset($elfinder_xh))
 {
 	initvar('admin');
 	initvar('post');


### PR DESCRIPTION
Due to cmsimple-xh/cmsimple-xh#21 the plugin administration is not
available anymore. We fix that by using the new
`XH_wantsPluginAdministration()` API, if available, falling back to the
old-style administration detection, otherwise.