### PR TITLE
Fix session incompatibility with XH 1.7

### DIFF
--- a/connectors/connector.minimal_xh.php
+++ b/connectors/connector.minimal_xh.php
@@ -10,6 +10,10 @@
 //error_reporting(0); // Set E_ALL for debuging
 
 if (session_id() == '') {
+	$temp = dirname(__FILE__) . '/../../../cmsimple/.sessionname';
+	if (file_exists($temp)) {
+		session_name(file_get_contents($temp));
+	}
     session_start();
 }
 

--- a/connectors/for_ckeditor_elfinder_html.php
+++ b/connectors/for_ckeditor_elfinder_html.php
@@ -19,13 +19,19 @@ if (!el_logincheck() ) { //Not login
 function el_logincheck()
 {
     if (session_id() == '') {
+		$filename = dirname(__FILE__) . '/../../../cmsimple/.sessionname';
+		if (file_exists($filename)) {
+			session_name(file_get_contents($filename));
+		}
         session_start();
     }
     $el_root = $_SESSION["elfinder"]["sn"];
 
     return isset($_SESSION['xh_password'])
-        && isset($_SESSION['xh_password'][$el_root])
+        && (isset($_SESSION['xh_password'][$el_root])
         && $_SESSION['xh_password'][$el_root] == $_SESSION['elfinder']['password']
+		|| isset($_SESSION['xh_password'])
+		&& $_SESSION['xh_password'] == $_SESSION['elfinder']['password'])
         && isset($_SESSION['xh_user_agent'])
         && $_SESSION['xh_user_agent'] == md5($_SERVER['HTTP_USER_AGENT']);
 }

--- a/connectors/for_tinymce4_elfinder_html.php
+++ b/connectors/for_tinymce4_elfinder_html.php
@@ -18,13 +18,19 @@ if (!el_logincheck() ) { //Not login
 function el_logincheck()
 {
     if (session_id() == '') {
+		$filename = dirname(__FILE__) . '/../../../cmsimple/.sessionname';
+		if (file_exists($filename)) {
+			session_name(file_get_contents($filename));
+		}
         session_start();
     }
     $el_root = $_SESSION["elfinder"]["sn"];
 
     return isset($_SESSION['xh_password'])
-        && isset($_SESSION['xh_password'][$el_root])
+        && (isset($_SESSION['xh_password'][$el_root])
         && $_SESSION['xh_password'][$el_root] == $_SESSION['elfinder']['password']
+		|| isset($_SESSION['xh_password'])
+		&& $_SESSION['xh_password'] == $_SESSION['elfinder']['password'])
         && isset($_SESSION['xh_user_agent'])
         && $_SESSION['xh_user_agent'] == md5($_SERVER['HTTP_USER_AGENT']);
 }


### PR DESCRIPTION
As of CMSimple_XH 1.7.0 the session uses a non-standard name, which
breaks compatibility with elFinder_xh 1.0.5. We fix this by checking
whether cmsimple/.sessionname exist, and if so we use its content to
set the appropriate session name before actually starting the session.

We also cater to `$_SESSION['xh_password']` now holding a string
instead of an array as before.